### PR TITLE
Fix rfc5054 compat

### DIFF
--- a/srp.c
+++ b/srp.c
@@ -575,9 +575,9 @@ struct SRPVerifier *  srp_verifier_new( SRP_HashAlgorithm alg, SRP_NGType ng_typ
        k = H_nn(alg, ng->N, ng->N, ng->g);
        
        /* B = kv + g^b */
-       BN_mul(tmp1, k, v, ctx);
+       BN_mod_mul(tmp1, k, v, ng->N, ctx);
        BN_mod_exp(tmp2, ng->g, b, ng->N, ctx);
-       BN_add(B, tmp1, tmp2);
+       BN_mod_add(B, tmp1, tmp2, ng->N, ctx);
        
        u = H_nn(alg, ng->N, A, B);
        


### PR DESCRIPTION
Hi!

I'm a colleague of the guy who did the last pull request to your nice little library.

While verifying your library for use with our own SRP implementation (which is based on Bouncy Castle), we found that your library is actually not compliant to RFC5054.

These two patches fix this, however they make csrp incompatible with older versions of itself, so you might want to introduce some sort of compatibility hack.

The patches have been verified against our implementation. I have also verified them against the RFC5054 test vectors manually. Note that these vectors only cover the first phase (key negotiation), not the verification phase. This is because TLS-SRP, specified in said RFC, does not require a verification phase.

Greetings from Berlin
  Ingo
