### PR TITLE
fix: Fixed compilation on Windows.

### DIFF
--- a/srp.c
+++ b/srp.c
@@ -27,7 +27,11 @@
  *
  */
 #ifdef WIN32
+# include <Windows.h>
 # include <Wincrypt.h>
+# ifdef X509_NAME
+#  undef X509_NAME
+# endif
 #else
 # include <sys/time.h>
 #endif


### PR DESCRIPTION
On Windows, `Wincrypt.h` is included.
This header references types defined in `Windows.h` but does not include this header itself.
It is then necessary to include `Windows.h` before `Wincrypt.h`

`Wincrypt.h` also defines a macro named `X509_NAME`, which conflicts with the type from OpenSSL:
```
typedef struct X509_name_st X509_NAME;
```

The macro from `Wincrypt.h` is undefined for fixing compilation.