### PR TITLE
fix: Fixed implicit integer conversions

### DIFF
--- a/srp.h
+++ b/srp.h
@@ -114,9 +114,9 @@ void srp_random_seed( const unsigned char * random_data, int data_length );
  */
 void srp_create_salted_verification_key( SRP_HashAlgorithm alg, 
                                          SRP_NGType ng_type, const char * username,
-                                         const unsigned char * password, int len_password,
-                                         const unsigned char ** bytes_s, int * len_s, 
-                                         const unsigned char ** bytes_v, int * len_v,
+                                         const unsigned char * password, unsigned int len_password,
+                                         const unsigned char ** bytes_s, unsigned int * len_s, 
+                                         const unsigned char ** bytes_v, unsigned int * len_v,
                                          const char * n_hex, const char * g_hex );
                                           
 
@@ -131,10 +131,10 @@ void srp_create_salted_verification_key( SRP_HashAlgorithm alg,
  * for new code.
  */
 struct SRPVerifier *  srp_verifier_new( SRP_HashAlgorithm alg, SRP_NGType ng_type, const char * username,
-                                        const unsigned char * bytes_s, int len_s, 
-                                        const unsigned char * bytes_v, int len_v,
-                                        const unsigned char * bytes_A, int len_A,
-                                        const unsigned char ** bytes_B, int * len_B,
+                                        const unsigned char * bytes_s, unsigned int len_s,
+                                        const unsigned char * bytes_v, unsigned int len_v,
+                                        const unsigned char * bytes_A, unsigned int len_A,
+                                        const unsigned char ** bytes_B, unsigned int * len_B,
                                         const char * n_hex, const char * g_hex,
                                         int rfc5054_compat );
 
@@ -168,7 +168,7 @@ void                  srp_verifier_verify_session( struct SRPVerifier * ver,
  * for new code. 
  */
 struct SRPUser *      srp_user_new( SRP_HashAlgorithm alg, SRP_NGType ng_type, const char * username,
-                                    const unsigned char * bytes_password, int len_password,
+                                    const unsigned char * bytes_password, unsigned int len_password,
                                     const char * n_hex, const char * g_hex,
                                     int rfc5054_compat );
                                     
@@ -186,14 +186,14 @@ int                   srp_user_get_session_key_length( struct SRPUser * usr );
 
 /* Output: username, bytes_A, len_A */
 void                  srp_user_start_authentication( struct SRPUser * usr, const char ** username, 
-                                                     const unsigned char ** bytes_A, int * len_A );
+                                                     const unsigned char ** bytes_A, unsigned int * len_A );
 
 /* Output: bytes_M, len_M  (len_M may be null and will always be 
  *                          srp_user_get_session_key_length() bytes in size) */
 void                  srp_user_process_challenge( struct SRPUser * usr, 
-                                                  const unsigned char * bytes_s, int len_s, 
-                                                  const unsigned char * bytes_B, int len_B,
-                                                  const unsigned char ** bytes_M, int * len_M );
+                                                  const unsigned char * bytes_s, unsigned int len_s,
+                                                  const unsigned char * bytes_B, unsigned int len_B,
+                                                  const unsigned char ** bytes_M, unsigned int * len_M );
                                                   
 /* bytes_HAMK must be exactly srp_user_get_session_key_length() bytes in size */
 void                  srp_user_verify_session( struct SRPUser * usr, const unsigned char * bytes_HAMK );


### PR DESCRIPTION
This library has several cases of implicit integer conversions that could lead to unwanted behavior, crashes, or compile-time errors.

This pull request aims to fix the issue using correct integer types as much as possible.

## 1 - `int` used as lengths

The public API uses `int` for buffer sizes. This has been corrected to use `unsigned int` instead in the following functions:

- `srp_create_salted_verification_key`
- `srp_verifier_new`
- `srp_user_new`
- `srp_user_start_authentication`
- `srp_user_process_challenge`

## 2 - Added checks for `hash_length` return value

The `hash_length` function can return `-1`.
Its return value is used as a parameter for functions such as `memcpy` or `BN_bin2bn`.

Extra checks have been added to handle this case, such as:

**Previous code**

```
return BN_bin2bn(buff, hash_length(alg), NULL);
```

**Modified code**

```
int hash_len = hash_length(alg);
if(hash_len <= 0)
    return 0;
return BN_bin2bn(buff, (size_t)hash_len, NULL);
```

Extra changes have been made in the following functions:

- `calculate_M`
- `calculate_H_AMK`

In order to handle a `-1` return value from `hash_length`, these functions now return a `bool`, indicating success or failure.

Checks have been added where these functions are called, in:

- `srp_user_process_challenge` - [See change](https://github.com/DigiDNA/csrp/commit/0c9c008ee3e40993add5b07ae86cee1b6c311f8a#diff-5144536c1faa90eaba1e97de54e59f36ab3555917f984537d58fbcddbffa01adR944)
- `srp_verifier_new` - [See change](https://github.com/DigiDNA/csrp/commit/0c9c008ee3e40993add5b07ae86cee1b6c311f8a#diff-5144536c1faa90eaba1e97de54e59f36ab3555917f984537d58fbcddbffa01adR659)

## 3 - Implicit conversion to 32-bits types

`size_t` is now used in some places instead of `int`, such as:

**Previous code**

```
int ulen = strlen(username);
```

**Modified code**

```
size_t ulen = strlen(username);
```
