### PR TITLE
Fixed the prototype of init_random to avoid compile errors

### DIFF
--- a/srp.c
+++ b/srp.c
@@ -457,7 +457,7 @@ static bool calculate_H_AMK( SRP_HashAlgorithm alg, unsigned char *dest, const B
 }
 
 
-static void init_random()
+static void init_random( void )
 {
     if (g_initialized)
         return;


### PR DESCRIPTION
Parameterless functions should be declared with `void` according to the C standard.
This fixes possible compile errors, such as `-Wstrict-prototypes`.

**C Standard - 6.7.6.3, item 10:**
> The special case of an unnamed parameter of type void as the only item in the list specifies that the function has no parameters.
