### PR TITLE
feat: Added srp_user_set_password

### DIFF
--- a/srp.c
+++ b/srp.c
@@ -842,6 +842,17 @@ const char * srp_user_get_username( struct SRPUser * usr )
     return usr->username;
 }
 
+void srp_user_set_password( struct SRPUser * usr, const unsigned char * bytes_password, unsigned int len_password )
+{
+    memset((void*)usr->password, 0, usr->password_len);
+    free((char *)usr->password);
+    
+    usr->password     = (const unsigned char *) malloc(len_password);
+    usr->password_len = len_password;
+    
+    memcpy((char *)usr->password, bytes_password, len_password);
+}
+
 const unsigned char * srp_user_get_session_key( struct SRPUser * usr, int * key_length )
 {
     if (key_length)

--- a/srp.h
+++ b/srp.h
@@ -178,6 +178,7 @@ int                   srp_user_is_authenticated( struct SRPUser * usr);
 
 
 const char *          srp_user_get_username( struct SRPUser * usr );
+void                  srp_user_set_password( struct SRPUser * usr, const unsigned char * bytes_password, unsigned int len_password );
 
 /* key_length may be null */
 const unsigned char * srp_user_get_session_key( struct SRPUser * usr, int * key_length );


### PR DESCRIPTION
This allows the password to be set after the creation of the user structure.
This is required when key derivation such as PBKDF2 is instructed by the server.