### PR TITLE
Added a function to retrieve H_AMK

### DIFF
--- a/srp.c
+++ b/srp.c
@@ -854,6 +854,18 @@ int                   srp_user_get_session_key_length( struct SRPUser * usr )
     return hash_length( usr->hash_alg );
 }
 
+const unsigned char * srp_user_get_h_amk( struct SRPUser * usr, int * h_length )
+{
+    if (h_length)
+        *h_length = hash_length( usr->hash_alg );
+    return usr->H_AMK;
+}
+
+int srp_user_get_h_amk_length( struct SRPUser * usr )
+{
+    return hash_length( usr->hash_alg );
+}
+
 /* Output: username, bytes_A, len_A */
 void  srp_user_start_authentication( struct SRPUser * usr, const char ** username, 
                                      const unsigned char ** bytes_A, unsigned int * len_A )

--- a/srp.h
+++ b/srp.h
@@ -184,6 +184,11 @@ const unsigned char * srp_user_get_session_key( struct SRPUser * usr, int * key_
 
 int                   srp_user_get_session_key_length( struct SRPUser * usr );
 
+/* h_length may be null */
+const unsigned char * srp_user_get_h_amk( struct SRPUser * usr, int * h_length );
+
+int                   srp_user_get_h_amk_length( struct SRPUser * usr );
+
 /* Output: username, bytes_A, len_A */
 void                  srp_user_start_authentication( struct SRPUser * usr, const char ** username, 
                                                      const unsigned char ** bytes_A, unsigned int * len_A );


### PR DESCRIPTION
Added convenience functions to retrieve bytes from `H_AMK` since the `SRPUser` is private.
Similar to `srp_user_get_session_key` and `srp_user_get_session_key_length`.